### PR TITLE
fix: missing terser-webpack-plugin dependency

### DIFF
--- a/gcs-boilerplate/package.json
+++ b/gcs-boilerplate/package.json
@@ -17,6 +17,7 @@
     "concurrently": "^8.2.2",
     "glob": "^10.4.2",
     "react": "^18.3.1",
+    "terser-webpack-plugin": "^5.3.10",
     "typescript": "^5.5.2",
     "webpack": "^5.92.1",
     "webpack-cli": "^5.1.4"


### PR DESCRIPTION
`webpack.config.js`にて`terser-webpack-plugin`が参照されているが、インストールされるパッケージに含まれていない。
結果`npm run dev`が動作しなくなっているのでdevDependenciesに追加。