### PR TITLE
BaseMachinaで管理されている外部ライブラリの型定義を追加

### DIFF
--- a/gcs-boilerplate/types.d.ts
+++ b/gcs-boilerplate/types.d.ts
@@ -1,2 +1,6 @@
 // `@basemachina/view` の型定義は公開されていないので、モジュールの宣言だけ行う
 declare module "@basemachina/view";
+// 外部ライブラリのモジュールの宣言を行う
+declare module "dayjs";
+declare module "@chakra-ui/react";
+declare module "react-chartjs-2";


### PR DESCRIPTION
# 概要
chakra-uiなどのパッケージを使用しているときに、tscの型検査が失敗します。
そこで、BaseMachinaが管理している外部ライブラリの型定義を追加しました。
`@types/dayjs`などの型定義パッケージがnpmから提供されていれば、それをdevDpendenciesに追加する形も可能ですが、いずれの外部ライブラリも型定義を本体に内包している形だったのでできませんでした。