### PR TITLE
set development mode explicitly for dev server

### DIFF
--- a/gcs-boilerplate/package.json
+++ b/gcs-boilerplate/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "build": "rm -rf dist && webpack",
-    "dev": "concurrently --kill-others \"webpack --watch\" \"bm-view-preview\""
+    "dev": "concurrently --kill-others \"webpack --watch --mode=development\" \"bm-view-preview\""
   },
   "devDependencies": {
     "@babel/core": "^7.24.7",


### PR DESCRIPTION
* `mode=production` がconfigで明示されているため、開発モード時のキャッシュが効いていなかった。
  - https://webpack.js.org/configuration/cache/#cache
* ライブリロードを早くするために、dev serverのmodeをdevelopmentとして明示する。